### PR TITLE
Building zenohd as part of dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ before_install:
   - docker exec build install ./opam /usr/local/bin/opam
   - docker exec build opam init --disable-sandboxing
   # copying repo inside container
-  - docker cp -r ../fog05 build/root/
+  - docker cp ../fog05 build/root/
 script:
   - docker exec build bash -c "eval \$(opam env) && cd /root/fog05 && ./build.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ before_install:
   - docker exec build install ./opam /usr/local/bin/opam
   - docker exec build opam init --disable-sandboxing
   # copying repo inside container
-  - docker cp ../fog05 build/root/
+  - docker cp ../fog05 build:/root/
 script:
   - docker exec build bash -c "eval \$(opam env) && cd /root/fog05 && ./build.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,13 @@ before_install:
   - docker run -it -d --name build debian:10-slim bash
   - docker exec build apt update
   # install deps
-  - docker exec build apt install git wget jq libev-dev libssl-dev python3 python3-dev python3-pip m4 pkg-config rsync unzip cmake -y
+  - docker exec build apt install git wget jq libev-dev libssl-dev python3 python3-dev python3-pip m4 pkg-config rsync unzip cmake sudo -y
   - docker exec build pip3 install pyangbind
   # install opam
   - docker exec build wget -O opam https://github.com/ocaml/opam/releases/download/2.0.6/opam-2.0.6-x86_64-linux
   - docker exec build install ./opam /usr/local/bin/opam
   - docker exec build opam init --disable-sandboxing
-  # clone repo at specific ref
-  - docker exec build git clone https://github.com/$TRAVIS_REPO_SLUG fog05
-  - docker exec build bash -c "cd fog05 && git checkout $TRAVIS_BRANCH"
+  # copying repo inside container
+  - docker cp -r ../fog05 build/root/
 script:
-  - docker exec build bash -c "eval \$(opam env) && cd fog05 && ./build.sh" 
+  - docker exec build bash -c "eval \$(opam env) && cd /root/fog05 && ./build.sh"

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ endif
 	sudo id -u fos  >/dev/null 2>&1 ||  sudo useradd -r -s /bin/false fos
 	sudo usermod -aG sudo fos
 	cp ./fos_build/zenohd/_build/default/zenoh-router-daemon/zenohd.exe /etc/fos/zenohd
-	cp ./fos_build/yaks/_build/default/src/yaks/yaks-plugin.cmxs /etc/fos/zenohd/yaks-plugin.cmxs
+	cp ./fos_build/yaks/_build/default/src/yaks/yaks-plugin.cmxs /etc/fos/yaks-plugin.cmxs
 
 ifeq "$(wildcard $(VAR_FOS_DIR))" ""
 	sudo mkdir -p /var/fos

--- a/Makefile
+++ b/Makefile
@@ -57,15 +57,17 @@ endif
 
 	sudo id -u fos  >/dev/null 2>&1 ||  sudo useradd -r -s /bin/false fos
 	sudo usermod -aG sudo fos
-ifeq ($(shell uname -m), x86_64)
-	curl -L -o /tmp/yaks.tar.gz https://www.dropbox.com/s/hx6w8qs9i4cx5r1/yaks.0.3.0.tar.gz
-else ifeq ($(shell uname -m), armv7l)
-	curl -L -o /tmp/yaks.tar.gz https://www.dropbox.com/s/wi65knmjcj74pgg/yaks.tar.gz
-else ifeq ($(shell uname -m), aarch64)
-	curl -L -o /tmp/yaks.tar.gz https://www.dropbox.com/s/oj4z80c1jwofv2a/yaks.tar.gz
-endif
-	tar -xzvf /tmp/yaks.tar.gz -C /etc/fos
-	rm -rf /tmp/yaks.tar.gz
+	cp ./fos_build/zenohd/_build/default/zenoh-router-daemon/zenohd.exe /etc/fos/zenohd
+	cp ./fos_build/yaks/_build/default/src/yaks/yaks-plugin.cmxs /etc/fos/zenohd/yaks-plugin.cmxs
+# ifeq ($(shell uname -m), x86_64)
+# 	curl -L -o /tmp/yaks.tar.gz https://www.dropbox.com/s/hx6w8qs9i4cx5r1/yaks.0.3.0.tar.gz
+# else ifeq ($(shell uname -m), armv7l)
+# 	curl -L -o /tmp/yaks.tar.gz https://www.dropbox.com/s/wi65knmjcj74pgg/yaks.tar.gz
+# else ifeq ($(shell uname -m), aarch64)
+# 	curl -L -o /tmp/yaks.tar.gz https://www.dropbox.com/s/oj4z80c1jwofv2a/yaks.tar.gz
+# endif
+# 	tar -xzvf /tmp/yaks.tar.gz -C /etc/fos
+# 	rm -rf /tmp/yaks.tar.gz
 
 ifeq "$(wildcard $(VAR_FOS_DIR))" ""
 	sudo mkdir -p /var/fos

--- a/Makefile
+++ b/Makefile
@@ -59,15 +59,6 @@ endif
 	sudo usermod -aG sudo fos
 	cp ./fos_build/zenohd/_build/default/zenoh-router-daemon/zenohd.exe /etc/fos/zenohd
 	cp ./fos_build/yaks/_build/default/src/yaks/yaks-plugin.cmxs /etc/fos/zenohd/yaks-plugin.cmxs
-# ifeq ($(shell uname -m), x86_64)
-# 	curl -L -o /tmp/yaks.tar.gz https://www.dropbox.com/s/hx6w8qs9i4cx5r1/yaks.0.3.0.tar.gz
-# else ifeq ($(shell uname -m), armv7l)
-# 	curl -L -o /tmp/yaks.tar.gz https://www.dropbox.com/s/wi65knmjcj74pgg/yaks.tar.gz
-# else ifeq ($(shell uname -m), aarch64)
-# 	curl -L -o /tmp/yaks.tar.gz https://www.dropbox.com/s/oj4z80c1jwofv2a/yaks.tar.gz
-# endif
-# 	tar -xzvf /tmp/yaks.tar.gz -C /etc/fos
-# 	rm -rf /tmp/yaks.tar.gz
 
 ifeq "$(wildcard $(VAR_FOS_DIR))" ""
 	sudo mkdir -p /var/fos
@@ -75,13 +66,10 @@ ifeq "$(wildcard $(VAR_FOS_DIR))" ""
 endif
 
 	echo "fos      ALL=(ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers > /dev/null
-	# sudo cp src/agent/_build/default/fos-agent/fos_agent.exe /etc/fos/agent
 	make -C plugins/plugin-os-linux install
 
 	sudo cp etc/yaks.service /lib/systemd/system/
 	sudo cp etc/yaks.target /lib/systemd/system/
-	sudo ln -sf /etc/fos/yaksd /usr/bin/yaksd
-	sudo ln -sf /etc/fos/agent /usr/bin/fagent
 
 lldp:
 	sudo mkdir -p /etc/fos/lldpd

--- a/build.sh
+++ b/build.sh
@@ -51,17 +51,17 @@ git clone http://github.com/atolab/zenoh-c
 cd zenoh-c
 git checkout $VER_ZENOH
 make
-make install
+sudo make install
 cd ..
 git clone http://github.com/atolab/zenoh-python
 cd zenoh-python
 git checkout $VER_ZENOH
-python3 setup.py install
+sudo python3 setup.py install
 cd ..
 git clone http://github.com/atolab/yaks-python
 cd yaks-python
 git checkout $VER_YAKS
-make install
+sudo  make install
 cd ..
 mkdir zenohd
 cp zenoh/Makefile zenohd/

--- a/build.sh
+++ b/build.sh
@@ -56,9 +56,20 @@ git clone http://github.com/atolab/yaks-python
 cd yaks-python
 git checkout $VER_YAKS
 make install
+cd ..
+mkdir zenohd
+cp zenoh/Makefile zenohd/
+cp zenoh/zenoh-router-daemon.opam zenohd/
+cp -r zenoh/src/zenoh-router-daemon zenohd/
+echo -e "(lang dune 1.11.1)\n(name zenohd)" > zenohd/dune-project
+sed -i 's/zenoh_proto/zenoh-proto/g' zenohd/zenoh-router-daemon/dune
+sed -i 's/zenoh_tx_inet/zenoh-tx-inet/g' zenohd/zenoh-router-daemon/dune
+sed -i 's/zenoh_router/zenoh-router/g' zenohd/zenoh-router-daemon/dune
+cd zenohd
+make
+cd ../..
 
 echo "[BUILD] Building Fog05"
 # build fog05
-cd ../..
 git submodule update --init --recursive
 make

--- a/build.sh
+++ b/build.sh
@@ -41,6 +41,12 @@ cd yaks-ocaml
 git checkout $VER_YAKS
 opam install . --working-dir -y
 cd ..
+git clone http://github.com/atolab/yaks
+cd yaks
+git checkout $VER_YAKS
+rm -rf src/yaks-be/yaks-be-influxdb/ src/yaks-be/yaks-be-sql/
+make
+cd ..
 git clone http://github.com/atolab/zenoh-c
 cd zenoh-c
 git checkout $VER_ZENOH


### PR DESCRIPTION
The goal of this PR are:

- [x] Build zenohd on a separated directory from zenoh
- [x] Build yaks as dependency
- [x] Use the local built zenohd and yaks-plugin instead of relying on external built one 